### PR TITLE
Drop support for Node.js < 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,11 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
@@ -24,16 +24,16 @@ jobs:
     timeout-minutes: 10
     services:
       mongodb:
-        image: mongo:4.2
+        image: mongo:5
         ports:
           - 27017:27017
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: |
@@ -50,16 +50,16 @@ jobs:
     timeout-minutes: 10
     services:
       mongodb:
-        image: mongo:4.2
+        image: mongo:5
         ports:
           - 27017:27017
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: |
@@ -71,7 +71,7 @@ jobs:
         cd test
         npm run coverage-ci
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         file: ./test/coverage/lcov.info
         fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-web-profile ChangeLog
 
+## 7.0.0 - 2023-10-TBD
+
+### Changed
+- **BREAKING**: Drop support for Node.js < 18.
+- Use `@digitalbazaar/http-client@4.0`. Requires Node.js 18+.
+
 ## 6.0.0 - 2022-08-19
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "eslint-plugin-unicorn": "^48.0.1",
     "jsdoc": "^4.0.2",
     "jsdoc-to-markdown": "^8.0.0"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://digitalbazaar.com"
   },
   "dependencies": {
-    "@digitalbazaar/http-client": "^3.1.0"
+    "@digitalbazaar/http-client": "^4.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "url": "https://github.com/digitalbazaar/bedrock-web-profile"
   },
   "devDependencies": {
-    "eslint": "^8.15.0",
-    "eslint-config-digitalbazaar": "^4.1.0",
-    "eslint-plugin-jsdoc": "^39.2.9",
-    "eslint-plugin-unicorn": "^43.0.2",
-    "jsdoc": "^3.6.10",
-    "jsdoc-to-markdown": "^7.1.1"
+    "eslint": "^8.51.0",
+    "eslint-config-digitalbazaar": "^5.0.1",
+    "eslint-plugin-jsdoc": "^46.8.2",
+    "eslint-plugin-unicorn": "^48.0.1",
+    "jsdoc": "^4.0.2",
+    "jsdoc-to-markdown": "^8.0.0"
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -9,21 +9,22 @@
     "coverage-ci": "node --preserve-symlinks test.js test --framework karma-coverage-ci"
   },
   "dependencies": {
-    "@bedrock/account": "^8.0.0",
+    "@bedrock/account": "^9.0.0",
     "@bedrock/app-identity": "^4.0.0",
     "@bedrock/core": "^6.0.1",
     "@bedrock/express": "^8.0.0",
     "@bedrock/https-agent": "^4.0.0",
-    "@bedrock/jsonld-document-loader": "^3.0.0",
-    "@bedrock/karma": "^5.1.0",
+    "@bedrock/jsonld-document-loader": "^4.0.0",
+    "@bedrock/karma": "^6.0.0",
     "@bedrock/mongodb": "^10.0.0",
-    "@bedrock/passport": "^10.0.0",
-    "@bedrock/profile": "^20.0.1",
-    "@bedrock/profile-http": "^19.0.1",
-    "@bedrock/security-context": "^7.0.0",
+    "@bedrock/passport": "^11.0.0",
+    "@bedrock/profile": "^23.0.1",
+    "@bedrock/profile-http": "^23.0.0",
+    "@bedrock/security-context": "^8.0.0",
     "@bedrock/server": "^5.0.0",
     "@bedrock/test": "^8.0.3",
     "@bedrock/validation": "^7.0.0",
-    "@bedrock/web-profile": "file:.."
+    "@bedrock/web-profile": "file:..",
+    "@vue/compiler-sfc": "^3.3.4"
   }
 }


### PR DESCRIPTION
- Use `@digitalbazaar/http-client@4.0.`